### PR TITLE
[qa] Cleanup isort and flake8 settings

### DIFF
--- a/runflake8
+++ b/runflake8
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e
-flake8 --max-line-length=110 \
-       --exclude=migrations,./tests/*settings*.py || exit 1
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,9 @@ default_section = THIRDPARTY
 skip = migrations
 
 [flake8]
+exclude = migrations,
+	  ./tests/*settings*.py
+max-line-length = 110
 # W503: line break before or after operator
 # W504: line break after or after operator
 # W605: invalid escape sequence


### PR DESCRIPTION
Any `runflake8` or `runisort` script which
uses any command line options are moved
to the `setup.cfg` as it's done in [django-freeradius](https://github.com/openwisp/django-freeradius),
which is cleaner and easier to review.
Closes #16