### PR TITLE
[requirements] removed repeated "openwisp-utils"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 django>=1.11,<2.2
 django-leaflet>=0.23,<0.25
 channels>=2.1.3,<2.2.0
-openwisp-utils>=0.2,<0.3.0
 Pillow>=4.3.0,<6.0
 openwisp-utils>=0.2.1,<0.4.0


### PR DESCRIPTION
openwisp-utils was mentioned 2 times in the requirements
file, removed the older version.