### PR TITLE
[dependencies] Updated Pillow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -398,7 +398,7 @@ Install sqlite:
 
 .. code-block:: shell
 
-    sudo apt-get install sqlite3 libsqlite3-dev libsqlite3-mod-spatialite
+    sudo apt-get install sqlite3 libsqlite3-dev libsqlite3-mod-spatialite gdal-bin
 
 Install your forked repo:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=1.11,<2.2
 django-leaflet>=0.23,<0.25
 channels>=2.1.3,<2.4.0
-Pillow>=4.3.0,<6.2
+Pillow>=6.2.0,<=6.3.0
 openwisp-utils>=0.2.1,<0.4.0


### PR DESCRIPTION
Closes #23 
I have updated pillow to be version 6 or higher and installed it successfully (might need to edit the docs about install gdal-bin via apt), and floor-plans and locations hopefully work as needed.
![floor-plan django-loci](https://user-images.githubusercontent.com/6494023/70163982-3b4b5980-1675-11ea-972d-e31a21f61989.png)
![Locations django-loci](https://user-images.githubusercontent.com/6494023/70163983-3be3f000-1675-11ea-83cf-27fbe6215abb.png)

