### PR TITLE
[ux] Fix loci fields hidden when error occurs

### DIFF
--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -9,7 +9,6 @@ django.jQuery(function ($) {
     var $outdoor = $('.loci.coords'),
         $indoor = $('.indoor.coords'),
         $allSections = $('.coords'),
-        $geoRows = $('.loci.coords .form-row'),
         $geoEdit = $('.field-name, .field-type, .field-is_mobile, ' +
                      '.field-address, .field-geometry', '.loci.coords'),
         $indoorRows = $('.indoor.coords .form-row:not(.field-indoor)'),
@@ -119,12 +118,10 @@ django.jQuery(function ($) {
         if (!initial) { resetDeviceLocationForm(); }
         if (value === 'new') {
             $outdoor.show();
-            $geoRows.hide();
             $typeRow.show();
             indoorForm(value);
         } else if (value === 'existing') {
             $outdoor.show();
-            $geoRows.hide();
             $locationRow.show();
         }
     }


### PR DESCRIPTION
`$geoRows.hide()` causing the loci coords fields to hidden by default, even if error occurs.
It's because *initially*, locationSelectionChange will **not** reset the form, so when user already set the `Location selection` and `Type` field then try to save it, if there's an error occurs, then `.loci.coords .form-row` fields will be hidden nevertheless because this `$geoRows.hide()` calls, even though the fields should not be hidden. This of course can confuse users because the UI inconsistency.

Closes #38 