### PR TITLE
[typo] Correcting Independent spelling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     long_description=open('README.rst').read(),
     url='http://openwisp.org',
     download_url='https://github.com/openwisp/django-loci/releases',
-    platforms=['Platform Indipendent'],
+    platforms=['Platform Independent'],
     keywords=['django', 'gis'],
     packages=find_packages(exclude=['tests', 'docs']),
     include_package_data=True,


### PR DESCRIPTION
It should be `Independent` and not `Indipendent`
:smile:  