### PR TITLE
[ux] When WebUI is too narrow geography map disappears

### DIFF
--- a/django_loci/static/django-loci/css/loci.css
+++ b/django_loci/static/django-loci/css/loci.css
@@ -36,3 +36,8 @@ input[type=text]{ width: 320px }
     font-size: 14px;
 }
 #floorplan_set-group{ display: none }
+@media (max-width: 767px){
+    .field-geometry > div{
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
Sets the flex direction of the inner div wrapping the elements in the .form-row.field_geometry div to column when the screen size is less than 768px.

Fixes #43