### PR TITLE
[model] Allow indoor location without indoor coords #54

### DIFF
--- a/django_loci/base/models.py
+++ b/django_loci/base/models.py
@@ -160,6 +160,9 @@ class AbstractObjectLocation(TimeStampedEditableModel):
         # allow empty values for outdoor locations
         elif self.location.type != 'indoor' and self.indoor in [None, '']:
             return
+        # allow empty values for indoor whose coordinates are not yet received
+        elif self.location.type == 'indoor' and self.indoor in [None, ''] and not self.floorplan:
+            return
         # split indoor position
         position = []
         if self.indoor:

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -1,3 +1,6 @@
+/*global
+alert, confirm, console, Debug, opera, prompt, WSH
+*/
 /*
 this JS is shared between:
     - DeviceLocationForm
@@ -327,8 +330,14 @@ django.jQuery(function ($) {
     $('#content-main form').submit(function (e) {
         var indoorPosition = $('.field-indoor .floorplan-raw input').val();
         if ($type.val() === 'indoor' && !indoorPosition) {
-            e.preventDefault();
-            alert(gettext('Please set the indoor position before saving'));
+            if ($floorplanImage[0].files.length !== 0 && !indoorPosition) {
+                alert('Please set the indoor position before saving');
+                e.preventDefault();
+            } else if ($floorplanImage[0].files.length === 0 && !indoorPosition) {
+                var confirmation = confirm('Do you want to save this indoor' +
+                                        'location without indoor coordinates?');
+                if (!confirmation) { e.preventDefault(); }
+            }
         }
     });
 

--- a/django_loci/tests/base/test_models.py
+++ b/django_loci/tests/base/test_models.py
@@ -124,12 +124,15 @@ class BaseTestModels(TestLociMixin):
         self._test_indoor_position_validation_error(ol)
         ol.indoor = 'TOTALLY.WRONG'
         self._test_indoor_position_validation_error(ol)
-        ol.indoor = ''
-        self._test_indoor_position_validation_error(ol)
-        ol.indoor = None
-        self._test_indoor_position_validation_error(ol)
         ol.indoor = '100.2300,-45.23454'
         ol.full_clean()
+        # allow empty indoor for location whose indoor coordinates are not yet received
+        ol.indoor = ''
+        ol.full_clean()
+        ol.save()
+        ol.indoor = None
+        ol.full_clean()
+        ol.save()
         # outdoor allows empty but not invalid values
         loc.type = 'outdoor'
         loc.full_clean()


### PR DESCRIPTION
Fixed the issue by adding a confirmation script to the
loci.js which gives the opportunity to the admin to
confirm if he/she wish to save the indoor location
without indoor coords. Also modified the admin to make
sure this is saved without validation errors.
I also modified the model of object_location to allow
indoors to be None when type is indoor and no floorplan
is provided.

Fixes #54