### PR TITLE
[fix] Fix strict_test setting naming

### DIFF
--- a/django_loci/settings.py
+++ b/django_loci/settings.py
@@ -4,7 +4,7 @@ from django.utils.module_loading import import_string
 
 DJANGO_LOCI_GEOCODER = getattr(settings, 'DJANGO_LOCI_GEOCODER', 'ArcGIS')
 DJANGO_LOCI_GEOCODE_STRICT_TEST = getattr(
-    settings, 'DJANGO_LOCI_STRICT_GEOCODE_TEST', True
+    settings, 'DJANGO_LOCI_GEOCODE_STRICT_TEST', True
 )
 DJANGO_LOCI_GEOCODE_FAILURE_DELAY = getattr(
     settings, 'DJANGO_LOCI_GEOCODE_FAILURE_DELAY', 1


### PR DESCRIPTION
Setting name of `DJANGO_LOCI_GEOCODE_STRICT_TEST` should be the same as in settings, app_settings and docs.