### PR TITLE
[fix] Fixed not assigning of an existing geographic location #85

### DIFF
--- a/django_loci/static/django-loci/css/loci.css
+++ b/django_loci/static/django-loci/css/loci.css
@@ -4,7 +4,6 @@
 /* hide redundant heading in objectlocationinline */
 .loci.coords > h2{ display: none }
 /* improve raw_id_field look */
-/* .coords .field-location input[type=text]{ display: none } */
 .field-location .related-lookup{
     width: auto;
     padding-left: 20px;

--- a/django_loci/static/django-loci/css/loci.css
+++ b/django_loci/static/django-loci/css/loci.css
@@ -4,7 +4,7 @@
 /* hide redundant heading in objectlocationinline */
 .loci.coords > h2{ display: none }
 /* improve raw_id_field look */
-.coords .field-location input[type=text]{ display: none }
+/* .coords .field-location input[type=text]{ display: none } */
 .field-location .related-lookup{
     width: auto;
     padding-left: 20px;

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -27,6 +27,7 @@ django.jQuery(function ($) {
         $locationSelection = $locationSelectionRow.find('select'),
         $locationRow = $('.loci.coords .field-location'),
         $location = $locationRow.find('select, input'),
+        $locationSelect = $locationRow.find('a'),
         $locationLabel = $('.field-location .item-label'),
         $name = $('.field-name input', '.loci.coords'),
         $address = $('.coords .field-address input, #location_form .field-address input'),
@@ -271,7 +272,7 @@ django.jQuery(function ($) {
             loadIndoor();
         }
     }
-
+    $locationSelect.on('focus', locationChange);
     $location.change(locationChange);
     locationChange(null, true);
 


### PR DESCRIPTION
Problem was that when we select an existing ``geo location``, ``locationChange`` was not triggered because input was not modified by user. So we need to listen some other event caused by user and which may change ``geo location``.

closes #85