### PR TITLE
[fix] Use storage backend method for deleting FloorPlan.image

### DIFF
--- a/django_loci/base/models.py
+++ b/django_loci/base/models.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -119,9 +118,9 @@ class AbstractFloorPlan(TimeStampedEditableModel):
             raise ValidationError(msg)
 
     def _remove_image(self):
-        path = self.image.path
-        if os.path.isfile(path):
-            os.remove(path)
+        path = self.image.name
+        if self.image.storage.exists(path):
+            self.image.delete(save=False)
         else:
             msg = 'floorplan image not found while deleting {0}:\n{1}'
             logger.error(msg.format(self, path))

--- a/django_loci/storage.py
+++ b/django_loci/storage.py
@@ -1,10 +1,7 @@
-import os
-
-from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 
 
-class OverwriteStorage(FileSystemStorage):
+class OverwriteMixin:
     floorplan_upload_dir = "floorplans"
 
     @classmethod
@@ -21,5 +18,9 @@ class OverwriteStorage(FileSystemStorage):
         removes file if it already exists
         """
         if self.exists(name):
-            os.remove(os.path.join(settings.MEDIA_ROOT, name))
+            self.delete(name)
         return name
+
+
+class OverwriteStorage(OverwriteMixin, FileSystemStorage):
+    pass

--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import responses
 from django.urls import reverse
@@ -63,7 +62,7 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
         loc = self._create_location(name='test-admin-location-1', type='indoor')
         fl = self._create_floorplan(location=loc)
         # remove floorplan image
-        os.remove(fl.image.path)
+        fl.image.delete(save=False)
         url = reverse('{0}_location_change'.format(self.url_prefix), args=[loc.pk])
         r = self.client.get(url)
         self.assertContains(r, 'test-admin-location-1')
@@ -73,7 +72,7 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
         loc = self._create_location(name='test-admin-location-1', type='indoor')
         fl = self._create_floorplan(location=loc)
         # remove floorplan image
-        os.remove(fl.image.path)
+        fl.image.delete(save=False)
         url = reverse('{0}_floorplan_change'.format(self.url_prefix), args=[fl.pk])
         r = self.client.get(url)
         self.assertContains(r, 'test-admin-location-1')

--- a/django_loci/tests/base/test_models.py
+++ b/django_loci/tests/base/test_models.py
@@ -1,5 +1,3 @@
-import os
-
 from django.core.exceptions import ValidationError
 
 from .. import TestLociMixin
@@ -51,12 +49,13 @@ class BaseTestModels(TestLociMixin):
         self.assertEqual(name, '{0}.jpg'.format(fl.id))
         self.assertEqual(dir_, 'floorplans')
         # delete
+        image_path = fl.image.file.name
         fl.delete()
-        self.assertFalse(os.path.isfile(fl.image.file.name))
+        self.assertFalse(fl.image.storage.exists(image_path))
 
     def test_floorplan_delete_corner_case(self):
         fl = self._create_floorplan()
-        os.remove(fl.image.path)
+        fl.image.storage.delete(fl.image.file.name)
         # there should be no failure
         fl.delete()
 


### PR DESCRIPTION
The previous code used the "os" module for deleting resisdual
floorplan image files. This causes issues when the project uses
a file storage backend other than based on file system.

Added OverwriteMixin to extend storage classes to provide
overwrite functionality to the storage backend.