### PR TITLE
[change] Use DEFAULT_STORAGE_CLASS as base for OverwriteStorage #107

### DIFF
--- a/django_loci/storage.py
+++ b/django_loci/storage.py
@@ -1,4 +1,7 @@
-from django.core.files.storage import FileSystemStorage
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+DefaultFileStorageClass = import_string(getattr(settings, 'DEFAULT_FILE_STORAGE'))
 
 
 class OverwriteMixin:
@@ -22,5 +25,5 @@ class OverwriteMixin:
         return name
 
 
-class OverwriteStorage(OverwriteMixin, FileSystemStorage):
+class OverwriteStorage(OverwriteMixin, DefaultFileStorageClass):
     pass

--- a/django_loci/storage.py
+++ b/django_loci/storage.py
@@ -26,4 +26,9 @@ class OverwriteMixin:
 
 
 class OverwriteStorage(OverwriteMixin, DefaultFileStorageClass):
+    """
+    Adds the overwrite functionality to the file storage class
+    currently in-use by the Django project.
+    """
+
     pass


### PR DESCRIPTION
The DEFAULT_STORAGE_CLASS will be used for creating OverwriteStorage class.

Closes #107