### PR TITLE
[fix:ux] Fixed outdoor location selection in floorplans #93

### DIFF
--- a/django_loci/base/admin.py
+++ b/django_loci/base/admin.py
@@ -51,11 +51,9 @@ class AbstractFloorPlanAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
     save_on_top = True
 
     def get_form(self, request, obj=None, **kwargs):
-        from ..models import FloorPlan
-
         form = super(AbstractFloorPlanAdmin, self).get_form(request, obj, **kwargs)
         form.base_fields['location'].widget = LocationRawIdWidget(
-            rel=FloorPlan._meta.get_field('location').remote_field, admin_site=site
+            rel=self.model._meta.get_field('location').remote_field, admin_site=site
         )
         return form
 

--- a/django_loci/base/admin.py
+++ b/django_loci/base/admin.py
@@ -2,6 +2,8 @@ import json
 
 from django import forms
 from django.contrib import admin
+from django.contrib.admin import widgets
+from django.contrib.admin.sites import site
 from django.contrib.contenttypes.admin import GenericStackedInline
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
@@ -28,12 +30,34 @@ class AbstractFloorPlanForm(forms.ModelForm):
         css = {'all': ('django-loci/css/loci.css',)}
 
 
+class LocationRawIdWidget(widgets.ForeignKeyRawIdWidget):
+    """
+    When selecting a location object
+    via a popup window in the floorplan
+    admin add view, display only indoor locations
+    """
+
+    def url_parameters(self):
+        url_params = super().url_parameters()
+        url_params['type__exact'] = 'indoor'
+        return url_params
+
+
 class AbstractFloorPlanAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
     list_display = ['__str__', 'location', 'floor', 'created', 'modified']
     list_select_related = ['location']
     search_fields = ['location__name']
     raw_id_fields = ['location']
     save_on_top = True
+
+    def get_form(self, request, obj=None, **kwargs):
+        from ..models import FloorPlan
+
+        form = super(AbstractFloorPlanAdmin, self).get_form(request, obj, **kwargs)
+        form.base_fields['location'].widget = LocationRawIdWidget(
+            rel=FloorPlan._meta.get_field('location').remote_field, admin_site=site
+        )
+        return form
 
 
 class AbstractLocationForm(forms.ModelForm):

--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -77,6 +77,33 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
         r = self.client.get(url)
         self.assertContains(r, 'test-admin-location-1')
 
+    def test_floorplan_add_view_filters_indoor_location(self):
+        self._login_as_admin()
+        loc_indoor = self._create_location(
+            name='test-admin-indoor-location', type='indoor'
+        )
+        loc_outdoor = self._create_location(
+            name='test-admin-outdoor-location', type='outdoor'
+        )
+        url = reverse('{0}_floorplan_add'.format(self.url_prefix))
+        filter_url = '/admin/django_loci/location/?_to_field=id&type__exact=indoor'
+        r1 = self.client.get(url)
+        self.assertContains(
+            r1,
+            f"""
+                <a href="{filter_url}"
+                class="related-lookup" id="lookup_id_location" title="Lookup">
+                    Select item
+                </a>
+            """,
+            html=True,
+        )
+        # Ensure that when the user clicks on the
+        # filter URL only indoor locations are displayed
+        r2 = self.client.get(filter_url)
+        self.assertContains(r2, f'{loc_indoor.name}</a>')
+        self.assertNotContains(r2, f'{loc_outdoor.name}</a>')
+
     def test_is_mobile_location_json_view(self):
         self._login_as_admin()
         loc = self._create_location(is_mobile=True, geometry=None)


### PR DESCRIPTION
When selecting a location object via a popup window in the `floorplan` admin add view, display only **indoor locations**.

#### Before

![Screenshot from 2023-03-22 15-43-08](https://user-images.githubusercontent.com/56113566/226871605-687efc4a-3499-41ce-9713-c02969454598.png)

#### After

![Screenshot from 2023-03-22 15-41-52](https://user-images.githubusercontent.com/56113566/226871254-093ca0c0-d563-4d5b-bec8-36bcfda23695.png)

Fixes #93