### PR TITLE
[fix] Fixed failing of indoor location test in openwisp-controller

### DIFF
--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -7,6 +7,7 @@ from .. import TestAdminMixin, TestLociMixin
 
 
 class BaseTestAdmin(TestAdminMixin, TestLociMixin):
+    app_label = 'django_loci'
     geocode_url = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/'
 
     def test_location_list(self):
@@ -86,7 +87,9 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
             name='test-admin-outdoor-location', type='outdoor'
         )
         url = reverse('{0}_floorplan_add'.format(self.url_prefix))
-        filter_url = '/admin/django_loci/location/?_to_field=id&type__exact=indoor'
+        filter_url = (
+            f'/admin/{self.app_label}/location/?_to_field=id&type__exact=indoor'
+        )
         r1 = self.client.get(url)
         self.assertContains(
             r1,


### PR DESCRIPTION
Fixed a failing indoor location test in the `'geo'` app of `openwisp-controller` by modifying the `filter_url` to consider the `app_label` during execution. Previously, the test `'test_floorplan_add_view_filters_indoor_location'` was failing due to a hardcoded `filter_url`.

![Screenshot from 2023-04-19 20-27-32](https://user-images.githubusercontent.com/56113566/233116311-5d8dcec8-4765-4cf4-930c-f93af2d1a1c3.png)

