### PR TITLE
[fix] Fixed location inline form on Django 4.2 #115

### DIFF
--- a/django_loci/static/django-loci/css/loci.css
+++ b/django_loci/static/django-loci/css/loci.css
@@ -35,6 +35,9 @@ input[type=text]{ width: 320px }
     text-align: center;
     font-size: 14px;
 }
+.form-row.field-geometry .flex-container {
+    display: block;
+}
 #floorplan_set-group{ display: none }
 @media (max-width: 767px){
     .field-geometry > div{

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -204,7 +204,9 @@ django.jQuery(function ($) {
     // `dismissAddAnotherPopup()` in Django's RelatedObjectLookups.js to
     // trigger change event when an ID is selected or added via popup.
     function triggerChangeOnField(win, chosenId) {
-        $(document.getElementById(win.name)).change();
+        // In Django 4.2, the popup index is appended to the window name.
+        // Hence, we remove that before selecting the element.
+        $(document.getElementById(win.name.replace(/__\d+$/, ''))).change();
     }
     window.ORIGINAL_dismissRelatedLookupPopup = window.dismissRelatedLookupPopup;
     window.dismissRelatedLookupPopup = function (win, chosenId) {


### PR DESCRIPTION
In Django 4.2, the window name scheme for related object lookup changed. This caused bug in triggering change event for the location field.

Related to #115