### PR TITLE
[fix] Fixed ObjectLocation admin read-only mode #95

### DIFF
--- a/django_loci/admin.py
+++ b/django_loci/admin.py
@@ -1,5 +1,3 @@
-from functools import partialmethod
-
 from django.contrib import admin
 
 from .base.admin import (
@@ -21,13 +19,6 @@ class FloorPlanForm(AbstractFloorPlanForm):
 
 class FloorPlanAdmin(AbstractFloorPlanAdmin):
     form = FloorPlanForm
-
-    # override get_form method to pass user to form
-    # for handling permissions
-    def get_form(self, request, obj=None, **kwargs):
-        form = super().get_form(request, obj, **kwargs)
-        form._user = request.user
-        return form
 
 
 class LocationForm(AbstractLocationForm):
@@ -62,13 +53,6 @@ class LocationAdmin(AbstractLocationAdmin):
             formset_kwargs['data']['floorplan_set-TOTAL_FORMS'] = '0'
         return formset_kwargs
 
-    # override get_form method to pass user to form
-    # for handling permissions
-    def get_form(self, request, obj=None, **kwargs):
-        form = super().get_form(request, obj, **kwargs)
-        form._user = request.user
-        return form
-
 
 class ObjectLocationForm(AbstractObjectLocationForm):
     class Meta(AbstractObjectLocationForm.Meta):
@@ -78,14 +62,6 @@ class ObjectLocationForm(AbstractObjectLocationForm):
 class ObjectLocationInline(AbstractObjectLocationInline):
     model = ObjectLocation
     form = ObjectLocationForm
-
-    # override get_formset method to pass user to form
-    def get_formset(self, request, obj=..., **kwargs):
-        formset = super().get_formset(request, obj, **kwargs)
-        formset._construct_form = partialmethod(
-            formset._construct_form, user=request.user
-        )
-        return formset
 
 
 admin.site.register(FloorPlan, FloorPlanAdmin)

--- a/django_loci/admin.py
+++ b/django_loci/admin.py
@@ -1,3 +1,5 @@
+from functools import partialmethod
+
 from django.contrib import admin
 
 from .base.admin import (
@@ -62,6 +64,14 @@ class ObjectLocationForm(AbstractObjectLocationForm):
 class ObjectLocationInline(AbstractObjectLocationInline):
     model = ObjectLocation
     form = ObjectLocationForm
+
+    # override get_formset method to pass user to form
+    def get_formset(self, request, obj=..., **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        formset._construct_form = partialmethod(
+            formset._construct_form, user=request.user
+        )
+        return formset
 
 
 admin.site.register(FloorPlan, FloorPlanAdmin)

--- a/django_loci/admin.py
+++ b/django_loci/admin.py
@@ -22,6 +22,13 @@ class FloorPlanForm(AbstractFloorPlanForm):
 class FloorPlanAdmin(AbstractFloorPlanAdmin):
     form = FloorPlanForm
 
+    # override get_form method to pass user to form
+    # for handling permissions
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form._user = request.user
+        return form
+
 
 class LocationForm(AbstractLocationForm):
     class Meta(AbstractLocationForm.Meta):

--- a/django_loci/admin.py
+++ b/django_loci/admin.py
@@ -55,6 +55,13 @@ class LocationAdmin(AbstractLocationAdmin):
             formset_kwargs['data']['floorplan_set-TOTAL_FORMS'] = '0'
         return formset_kwargs
 
+    # override get_form method to pass user to form
+    # for handling permissions
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form._user = request.user
+        return form
+
 
 class ObjectLocationForm(AbstractObjectLocationForm):
     class Meta(AbstractObjectLocationForm.Meta):

--- a/django_loci/base/admin.py
+++ b/django_loci/base/admin.py
@@ -1,4 +1,5 @@
 import json
+from functools import partialmethod
 
 from django import forms
 from django.contrib import admin
@@ -18,13 +19,41 @@ from openwisp_utils.admin import TimeReadonlyAdminMixin
 from ..base.geocoding_views import geocode_view, reverse_geocode_view
 from ..fields import GeometryField
 from ..widgets import FloorPlanWidget, ImageWidget
-from .models import AbstractLocation
+from .models import AbstractFloorPlan, AbstractLocation
 
 
-class AbstractFloorPlanForm(forms.ModelForm):
-    # adding image field to render it for view-only
-    # as 'AdminReadonly' renders widget if it is present in self.fields
-    image = forms.ImageField(widget=ImageWidget(), help_text=_('floor plan image'))
+class ReadOnlyMixin:
+    """Mixin for forms to handle field widgets for view-only users."""
+
+    def set_readonly_attribute(self, user, fields):
+        """
+        This method sets the read_only attribute on widget for the fields
+        which are required to be rendered as it is to view-only users. This is
+        done as 'AdminReadonlyField' renders the widget if 'read_only' is set on
+        the field's widget. Also the required field must be present in self.fields
+        """
+        app_label = self.Meta.model._meta.app_label
+        model_name = self.Meta.model._meta.model_name
+        if (
+            user
+            and user.has_perm(f'{app_label}.view_{model_name}')
+            and not user.has_perm(f'{app_label}.change_{model_name}')
+        ):
+            for field in fields:
+                if field in self.fields:
+                    setattr(self.fields[field].widget, 'read_only', True)
+            # Return 'True' to allow any further handling for view-only users
+            return True
+        return False
+
+
+class AbstractFloorPlanForm(ReadOnlyMixin, forms.ModelForm):
+    # define the image field to add it in self.fields
+    # to render it for view-only
+    image = forms.ImageField(
+        widget=ImageWidget(),
+        help_text=AbstractFloorPlan._meta.get_field('image').help_text,
+    )
 
     class Meta:
         exclude = tuple()
@@ -34,18 +63,10 @@ class AbstractFloorPlanForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # setting attributes basis user permissions
-        app_label = self.Meta.model._meta.app_label
-        model_name = self.Meta.model._meta.model_name
-        if (
-            getattr(self, '_user', None)
-            and self._user.has_perm(f'{app_label}.view_{model_name}')
-            and not self._user.has_perm(f'{app_label}.change_{model_name}')
-        ):
-            # set read_only attribute as 'AdminReadonlyField' renders if 'read_only' is set
-            setattr(self.fields['image'].widget, 'read_only', True)
-        # remove user attribute to avoid any side effects
-        self._user = None
+        if getattr(self, '_user', None):
+            self.set_readonly_attribute(self._user, ['image'])
+            # user is set on Form class which gets instantiated for each request
+            del self.__class__._user
 
 
 class LocationRawIdWidget(widgets.ForeignKeyRawIdWidget):
@@ -76,12 +97,14 @@ class AbstractFloorPlanAdmin(TimeReadonlyAdminMixin, admin.ModelAdmin):
             form.base_fields['location'].widget = LocationRawIdWidget(
                 rel=self.model._meta.get_field('location').remote_field, admin_site=site
             )
+        # pass user to form for handling permissions for readonly view
+        form._user = request.user
         return form
 
 
-class AbstractLocationForm(forms.ModelForm):
-    # adding geometry field to render it for view-only
-    # as 'AdminReadonly' renders widget if it is present in self.fields
+class AbstractLocationForm(ReadOnlyMixin, forms.ModelForm):
+    # define the geometry field to add it in self.fields
+    # to render it for view-only
     geometry = GeometryField(required=True)
 
     class Meta:
@@ -98,18 +121,10 @@ class AbstractLocationForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # setting attributes basis user permissions
-        app_label = self.Meta.model._meta.app_label
-        model_name = self.Meta.model._meta.model_name
-        if (
-            getattr(self, '_user', None)
-            and self._user.has_perm(f'{app_label}.view_{model_name}')
-            and not self._user.has_perm(f'{app_label}.change_{model_name}')
-        ):
-            # set read_only attribute as 'AdminReadonlyField' renders if 'read_only' is set
-            setattr(self.fields['geometry'].widget, 'read_only', True)
-        # remove user attribute to avoid any side effects
-        self._user = None
+        if getattr(self, '_user', None):
+            self.set_readonly_attribute(self._user, ['geometry'])
+            # user is set on Form class which gets instantiated for each request
+            del self.__class__._user
 
 
 class AbstractFloorPlanInline(TimeReadonlyAdminMixin, admin.StackedInline):
@@ -125,6 +140,13 @@ class AbstractLocationAdmin(TimeReadonlyAdminMixin, LeafletGeoAdmin):
 
     # This allows apps which extend django-loci to load this template with less hacks
     change_form_template = 'admin/django_loci/location_change_form.html'
+
+    # override get_form method to pass user to form
+    # for handling permissions for readonly view
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        form._user = request.user
+        return form
 
     def get_urls(self):
         # hardcoding django_loci as the prefix for the
@@ -197,7 +219,7 @@ class UnvalidatedChoiceField(forms.ChoiceField):
 _get_field = AbstractLocation._meta.get_field
 
 
-class AbstractObjectLocationForm(forms.ModelForm):
+class AbstractObjectLocationForm(ReadOnlyMixin, forms.ModelForm):
     FORM_CHOICES = (
         ('', _('--- Please select an option ---')),
         ('new', _('New')),
@@ -288,25 +310,15 @@ class AbstractObjectLocationForm(forms.ModelForm):
             self.fields['floorplan'].choices = floorplan_choices + [
                 (floorplan.pk, floorplan)
             ]
-        # setting attributes basis user permissions
-        app_label = self.Meta.model._meta.app_label
-        model_name = self.Meta.model._meta.model_name
-        if (
-            user
-            and user.has_perm(f'{app_label}.view_{model_name}')
-            and not user.has_perm(f'{app_label}.change_{model_name}')
-        ):
+
+        if self.set_readonly_attribute(user, ['geometry', 'image', 'indoor']):
             # For view only permissions, 'AdminReadonlyField' reads from instance
             for field, value in initial.items():
                 if field != 'floorplan':
                     setattr(self.instance, field, value)
                 else:
                     setattr(self.instance.floorplan, 'pk', value)
-            # setting read_only attribute as 'AdminReadonlyField' renders if 'read_only' is set
-            setattr(self.fields['geometry'].widget, 'read_only', True)
-            setattr(self.fields['image'].widget, 'read_only', True)
-            setattr(self.fields['indoor'].widget, 'read_only', True)
-            # adding id to indoor widget to display indoor position
+            # Added id to indoor widget to display indoor position
             self.fields['indoor'].widget.attrs.update({'id': 'id_indoor'})
         self.initial.update(initial)
 
@@ -461,4 +473,10 @@ class AbstractObjectLocationInline(ObjectLocationMixin, GenericStackedInline):
     Generic Inline + ObjectLocationMixin
     """
 
-    pass
+    # override get_formset method to pass user to form
+    def get_formset(self, request, obj=..., **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        formset._construct_form = partialmethod(
+            formset._construct_form, user=request.user
+        )
+        return formset

--- a/django_loci/channels/base.py
+++ b/django_loci/channels/base.py
@@ -41,10 +41,11 @@ class BaseLocationBroadcast(JsonWebsocketConsumer):
 
     def is_authorized(self, user, location):
         perm = '{0}.change_location'.format(self.model._meta.app_label)
+        # allow users with view permission
+        readperm = '{0}.view_location'.format(self.model._meta.app_label)
         authenticated = user.is_authenticated
-        return authenticated and (
-            user.is_superuser or (user.is_staff and user.has_perm(perm))
-        )
+        is_permitted = user.has_perm(perm) or user.has_perm(readperm)
+        return authenticated and (user.is_superuser or (user.is_staff and is_permitted))
 
     def send_message(self, event):
         self.send_json(event['message'])

--- a/django_loci/static/django-loci/css/floorplan-widget.css
+++ b/django_loci/static/django-loci/css/floorplan-widget.css
@@ -14,3 +14,9 @@
 p.change-image {
   margin-left: 170px;
 }
+/* Set .readonly to flex to ensure the floorplan-widget inherits the full width of 
+its parent flex container */
+.field-indoor .readonly {
+  display: flex;
+  width: 100%;
+}

--- a/django_loci/static/django-loci/css/loci.css
+++ b/django_loci/static/django-loci/css/loci.css
@@ -56,6 +56,14 @@ input[type="text"] {
 #floorplan_set-group {
   display: none;
 }
+/* hide image file input for readonly view */
+.field-image .readonly input {
+  display: none;
+}
+/* hide geometry edit tools for readonly view */
+.field-geometry .readonly .leaflet-draw.geometry {
+  display: none;
+}
 @media (max-width: 767px) {
   .field-geometry > div {
     flex-direction: column;

--- a/django_loci/static/django-loci/js/floorplan-inlines.js
+++ b/django_loci/static/django-loci/js/floorplan-inlines.js
@@ -7,6 +7,15 @@ django.jQuery(function ($) {
     ).length,
     type_change_event = function (e) {
       var value = $type_field.val();
+      // if value is undefined, check for readonly field
+      if (typeof value === "undefined") {
+        value = $(".field-type .readonly").text();
+        if (value && value.startsWith("Indoor")) {
+          $floorplan_set.show();
+        } else {
+          $floorplan_set.hide();
+        }
+      }
       if (value === "indoor") {
         $floorplan_set.show();
       } else if (value === "outdoor" && $floorplans_length === 0) {

--- a/django_loci/static/django-loci/js/floorplan-widget.js
+++ b/django_loci/static/django-loci/js/floorplan-widget.js
@@ -45,8 +45,13 @@
     } else {
       coordinates = undefined;
     }
+    var draggable = true;
+    // if readonly field, don't allow dragging
+    if ($indoorPosition.find(".readonly").length) {
+      draggable = false;
+    }
 
-    var marker = new L.marker(coordinates, { draggable: true });
+    var marker = new L.marker(coordinates, { draggable: draggable });
     marker.bindPopup(gettext("Drag to reposition"));
     marker.on("dragend", updateInput);
     if (coordinates) {

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -661,8 +661,4 @@ django.jQuery(function ($) {
         $locationSelectionRow.find(".readonly").text(),
     );
   }
-  // hide image input for view only users
-  if ($indoor.find(".field-image .readonly").length) {
-    $indoor.find(".field-image input").hide();
-  }
 });

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -126,7 +126,15 @@ django.jQuery(function ($) {
   }
 
   function indoorForm(selection) {
-    if ($type.val() !== "indoor") {
+    // fallbacks for view only users
+    var type = $type.val() || $typeRow.find(".readonly").text(),
+      floorplanValue =
+        $floorplanSelection.val() ||
+        $floorplanSelectionRow.find(".readonly").text(),
+      locationSelectionValue =
+        $locationSelection.val() ||
+        $locationSelectionRow.find(".readonly").text();
+    if (type !== "indoor") {
       return;
     }
     $indoorPositionRow.hide();
@@ -139,11 +147,11 @@ django.jQuery(function ($) {
       $floorplan.val("");
       $floorplanRow.hide();
     }
-    if ($locationSelection.val() === "new") {
+    if (locationSelectionValue === "new") {
       $floorplanSelection.val("new");
       $floorplanSelectionRow.hide();
     }
-    if (!$floorplanSelection.val()) {
+    if (!floorplanValue) {
       $indoorRows.hide();
       $floorplanSelectionRow.show();
     }
@@ -228,17 +236,23 @@ django.jQuery(function ($) {
   }
 
   function floorplanSelectionChange(e, initial) {
-    var value = $floorplanSelection.val(),
-      optionsLength = $floorplan.find("option").length;
+    // fallbacks for view only users
+    var value =
+        $floorplanSelection.val() ||
+        $floorplanSelectionRow.find(".readonly").text(),
+      optionsLength =
+        $floorplan.find("option").length ||
+        $floorplanSelectionRow.find(".readonly").length;
     // do not reset indoor form at first load
     if (!initial) {
       resetIndoorForm(true);
     }
     indoorForm(value);
-    if (value === "existing" && optionsLength > 1) {
+    // optionslength includes the placeholder option
+    if (value === "existing" && optionsLength >= 1) {
       $floorplanRow.show();
       // if no floorplan available, make it obvious
-    } else if (value === "existing" && optionsLength <= 1) {
+    } else if (value === "existing" && optionsLength < 1) {
       alert(gettext("This location has no floorplans available yet"));
       $floorplanSelection.val("");
     }
@@ -272,7 +286,9 @@ django.jQuery(function ($) {
   function locationChange(e, initial) {
     function loadIndoor() {
       indoorForm();
-      if ($type.val() !== "indoor") {
+      // fallback for view only users
+      var type = $type.val() || $typeRow.find(".readonly").text();
+      if (type !== "indoor") {
         $indoor.hide();
         return;
       }
@@ -599,6 +615,8 @@ django.jQuery(function ($) {
   } else {
     pk = window.location.pathname.split("/").slice("-3", "-2")[0];
   }
+  // fallback for view only users
+  var typeLength = $type.length || $typeRow.find(".readonly").length;
   // show mobile map (hide not relevant fields)
   if ($isMobile.prop("checked")) {
     listenForLocationUpdates(pk);
@@ -618,22 +636,33 @@ django.jQuery(function ($) {
       $noLocationDiv = $(".no-location", ".loci.coords");
     }
     // this is triggered in the location form page
-  } else if (!$type.length) {
+  } else if (!typeLength) {
     if (pk !== "location") {
       listenForLocationUpdates(pk);
     }
   }
   // show existing indoor
-  if ($floorplan.val()) {
+  // fallbacks for view only users
+  if ($floorplan.val() || $floorplanSelectionRow.find(".readonly").text()) {
     $indoor.show();
-    if ($floorplanSelection.val()) {
+    if (
+      $floorplanSelection.val() ||
+      $floorplanSelectionRow.find(".readonly").text()
+    ) {
       $indoorRows.show();
       $floorplanSelectionRow.hide();
     }
     // adding indoor
-  } else if ($type.val() === "indoor") {
+  } else if (($type.val() || $typeRow.find(".readonly").text()) === "indoor") {
     $indoor.show();
     $indoorRows.show();
-    indoorForm($locationSelection.val());
+    indoorForm(
+      $locationSelection.val() ||
+        $locationSelectionRow.find(".readonly").text(),
+    );
+  }
+  // hide image input for view only users
+  if ($indoor.find(".field-image .readonly").length) {
+    $indoor.find(".field-image input").hide();
   }
 });

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -20,7 +20,7 @@ django.jQuery(function ($) {
     $indoorRows = $(".indoor.coords .form-row:not(.field-indoor)"),
     $indoorEdit = $(".indoor.coords .form-row:not(.field-floorplan_selection)"),
     $indoorPositionRow = $(".indoor.coords .field-indoor"),
-    geometryId = $(".field-geometry label").attr("for"),
+    geometryId = $(".field-geometry label").attr("for") || "geometry", // fallback for readonly
     mapName = "leafletmap" + geometryId + "-map",
     loadMapName = "loadmap" + geometryId + "-map",
     $typeRow = $(".inline-group .field-type"),
@@ -150,7 +150,10 @@ django.jQuery(function ($) {
   }
 
   function locationSelectionChange(e, initial) {
-    var value = $locationSelection.val();
+    // get value from 'readonly' in case of view only permissions
+    var value =
+      $locationSelection.val() ||
+      $locationSelectionRow.find(".readonly").text();
     $allSections.hide();
     if (!initial) {
       resetDeviceLocationForm();
@@ -188,7 +191,8 @@ django.jQuery(function ($) {
   }
 
   function typeChange(e, initial) {
-    var value = $type.val(),
+    // get value from 'readonly' in case of view only permissions
+    var value = $type.val() || $typeRow.find(".readonly").text(),
       // floorplansLength for choice field includes the placeholder option so
       // need to subtract it.
       floorplansLength = $floorplan.find("option").length - 1;

--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -232,12 +232,12 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
         self.assertEqual(response.json(), expected)
 
     # for users with view only permissions to floorplans
-    def test_view_floorplans(self):
+    def test_readonly_floorplans(self):
         user = self.user_model.objects.create_user(
             username='admin', password='admin', email='admin@email.org', is_staff=True
         )
         # add view permission to client
-        view_permission = Permission.objects.filter(codename__in=["view_floorplan"])
+        view_permission = Permission.objects.filter(codename__in=['view_floorplan'])
         user.user_permissions.add(*view_permission)
         self.client.force_login(user)
         loc = self._create_location(name='test-admin-location-1', type='indoor')

--- a/django_loci/tests/base/test_admin_inline.py
+++ b/django_loci/tests/base/test_admin_inline.py
@@ -883,13 +883,13 @@ class BaseTestAdminInline(TestAdminMixin, TestLociMixin):
         )
 
     # for users with view only permissions to location
-    def test_view_location_with_floorplans(self):
+    def test_readonly_indoor_location(self):
         user = self.user_model.objects.create_user(
             username='admin', password='admin', email='admin@email.org', is_staff=True
         )
         # add view permission to client
         view_permission = Permission.objects.filter(
-            codename__in=["view_location", "view_floorplan"]
+            codename__in=['view_location', 'view_floorplan']
         )
         user.user_permissions.add(*view_permission)
         self.client.force_login(user)
@@ -910,13 +910,13 @@ class BaseTestAdminInline(TestAdminMixin, TestLociMixin):
         self.assertContains(r, loc.is_mobile)
 
     # for users with view only permissions to objectlocation
-    def test_view_objectlocation_with_floorplans(self):
+    def test_readonly_indoor_object_location(self):
         user = self.user_model.objects.create_user(
             username='admin', password='admin', email='admin@gmail.com', is_staff=True
         )
         # add view permission to client
         view_permission = Permission.objects.filter(
-            codename__in=["view_device", "view_objectlocation"]
+            codename__in=['view_device', 'view_objectlocation']
         )
         user.user_permissions.add(*view_permission)
         self.client.force_login(user)

--- a/django_loci/tests/base/test_admin_inline.py
+++ b/django_loci/tests/base/test_admin_inline.py
@@ -1,4 +1,6 @@
+from django.contrib.auth.models import Permission
 from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.humanize.templatetags.humanize import ordinal
 from django.db.models.fields.files import ImageFieldFile
 from django.urls import reverse
 
@@ -879,3 +881,66 @@ class BaseTestAdminInline(TestAdminMixin, TestLociMixin):
             .content_object,
             obj,
         )
+
+    # for users with view only permissions to location
+    def test_view_location_with_floorplans(self):
+        user = self.user_model.objects.create_user(
+            username='admin', password='admin', email='admin@email.org', is_staff=True
+        )
+        # add view permission to client
+        view_permission = Permission.objects.filter(
+            codename__in=["view_location", "view_floorplan"]
+        )
+        user.user_permissions.add(*view_permission)
+        self.client.force_login(user)
+        loc = self._create_location(name='test-admin-location-1', type='indoor')
+        fl = self._create_floorplan(location=loc)
+        url = reverse('{0}_location_change'.format(self.url_prefix), args=[loc.pk])
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        # assert if map is being rendered or not
+        self.assertContains(r, 'geometry-div-map')
+        # assert if inline fields are visible
+        self.assertContains(r, f'{loc.name} {ordinal(fl.floor)}')
+        self.assertContains(r, fl.floor)
+        self.assertContains(r, fl.image.url)
+        self.assertContains(r, loc.name)
+        self.assertContains(r, loc.address)
+        self.assertContains(r, loc.type)
+        self.assertContains(r, loc.is_mobile)
+
+    # for users with view only permissions to objectlocation
+    def test_view_objectlocation_with_floorplans(self):
+        user = self.user_model.objects.create_user(
+            username='admin', password='admin', email='admin@gmail.com', is_staff=True
+        )
+        # add view permission to client
+        view_permission = Permission.objects.filter(
+            codename__in=["view_device", "view_objectlocation"]
+        )
+        user.user_permissions.add(*view_permission)
+        self.client.force_login(user)
+        obj = self._create_object(name='test-admin-object-1')
+        loc = self._create_location(name='test-admin-location-1', type='indoor')
+        fl = self._create_floorplan(location=loc)
+        ol = self._create_object_location(
+            content_object=obj, location=loc, floorplan=fl
+        )
+        url = reverse('{0}_device_change'.format(self.object_url_prefix), args=[obj.pk])
+        r = self.client.get(url)
+        self.assertEqual(r.status_code, 200)
+        # assert if map is being rendered or not
+        self.assertContains(r, 'geometry-div-map')
+        self.assertContains(r, 'id_indoor_map')
+        # id is required for indoor map to render
+        self.assertContains(r, 'id="id_indoor"')
+        # assert if inline fields are visible
+        self.assertContains(r, f'{loc.name} {ordinal(fl.floor)} floor')
+        self.assertContains(r, fl.floor)
+        self.assertContains(r, fl.image.url)
+        self.assertContains(r, loc.name)
+        self.assertContains(r, loc.address)
+        self.assertContains(r, loc.type)
+        self.assertContains(r, loc.is_mobile)
+        self.assertContains(r, obj.name)
+        self.assertContains(r, ol.indoor)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Reference to Existing Issue

Closes #95.

## Description of Changes

For view only permission, django admin uses 'AdminReadonlyField' for rendering data which looks for form fields in the model instance. And for widget to render 'read_only' must be set True. Setting the attributes to instance and 'read_only' geometry widget allowed the data to be viewed and map to render.
