### PR TITLE
[refactor] Simplify formset handling for outdoor locations in admin $157

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           - "3.12"
           - "3.13"
         django-version:
-          - django~=4.1.0
           - django~=4.2.0
           - django~=5.0.0
           - django~=5.1.0
@@ -46,7 +45,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    
+
     - name: Cache APT packages
       uses: actions/cache@v4
       with:

--- a/django_loci/admin.py
+++ b/django_loci/admin.py
@@ -35,24 +35,6 @@ class LocationAdmin(AbstractLocationAdmin):
     form = LocationForm
     inlines = [FloorPlanInline]
 
-    # kept for backward compatibility with Django 3.2.18
-    def _create_formsets(self, request, obj, change):
-        # 'data' is not present in POST request for django 3.2.18
-        if request.method == 'POST' and not request.POST.get('data', None):
-            data = request.POST.copy()
-            if data['type'] == 'outdoor':
-                data['floorplan_set-TOTAL_FORMS'] = '0'
-            request.POST = data
-        return super()._create_formsets(request, obj, change)
-
-    # for django >= 4.0
-    def get_formset_kwargs(self, request, obj, inline, prefix):
-        formset_kwargs = super().get_formset_kwargs(request, obj, inline, prefix)
-        # manually set TOTAL_FORMS to 0 if the type is outdoor to avoid floorplan form creation
-        if request.method == 'POST' and formset_kwargs['data']['type'] == 'outdoor':
-            formset_kwargs['data']['floorplan_set-TOTAL_FORMS'] = '0'
-        return formset_kwargs
-
 
 class ObjectLocationForm(AbstractObjectLocationForm):
     class Meta(AbstractObjectLocationForm.Meta):

--- a/django_loci/base/admin.py
+++ b/django_loci/base/admin.py
@@ -144,6 +144,13 @@ class AbstractLocationAdmin(TimeReadonlyAdminMixin, LeafletGeoAdmin):
             )
         return JsonResponse({'choices': choices})
 
+    def get_formset_kwargs(self, request, obj, inline, prefix):
+        formset_kwargs = super().get_formset_kwargs(request, obj, inline, prefix)
+        # manually set TOTAL_FORMS to 0 if the type is outdoor to avoid floorplan form creation
+        if request.method == 'POST' and formset_kwargs['data']['type'] == 'outdoor':
+            formset_kwargs['data']['floorplan_set-TOTAL_FORMS'] = '0'
+        return formset_kwargs
+
 
 class UnvalidatedChoiceField(forms.ChoiceField):
     """

--- a/django_loci/tests/base/test_admin_inline.py
+++ b/django_loci/tests/base/test_admin_inline.py
@@ -769,20 +769,23 @@ class BaseTestAdminInline(TestAdminMixin, TestLociMixin):
     def test_add_outdoor_with_floorplan(self):
         self._login_as_admin()
         p = 'floorplan_set'
-        params = {
-            'name': 'test-add-outdoor-with-floorplan',
-            'type': 'outdoor',
-            'geometry': 'SRID=4326;POINT (12.512324 41.898703)',
-            'address': 'Piazza Venezia, Roma, Italia',
-            '{0}-0-floor'.format(p): '1',
-            '{0}-0-image'.format(p): self._get_simpleuploadedfile(),
-            '{0}-0-id'.format(p): '',
-            '{0}-0-location'.format(p): '',
-            '{0}-TOTAL_FORMS'.format(p): '1',
-            '{0}-INITIAL_FORMS'.format(p): '0',
-            '{0}-MIN_NUM_FORMS'.format(p): '0',
-            '{0}-MAX_NUM_FORMS'.format(p): '1',
-        }
+        params = self.params
+        params.update(
+            {
+                'name': 'test-add-outdoor-with-floorplan',
+                'type': 'outdoor',
+                'geometry': 'SRID=4326;POINT (12.512324 41.898703)',
+                'address': 'Piazza Venezia, Roma, Italia',
+                '{0}-0-floor'.format(p): '1',
+                '{0}-0-image'.format(p): self._get_simpleuploadedfile(),
+                '{0}-0-id'.format(p): '',
+                '{0}-0-location'.format(p): '',
+                '{0}-TOTAL_FORMS'.format(p): '1',
+                '{0}-INITIAL_FORMS'.format(p): '0',
+                '{0}-MIN_NUM_FORMS'.format(p): '0',
+                '{0}-MAX_NUM_FORMS'.format(p): '1',
+            }
+        )
         location_url = '{0}_{1}_add'.format(
             self.url_prefix, self.location_model.__name__.lower()
         )


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Related to #157

Please [open a new issue](https://github.com/openwisp/django-loci/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Moved logic for rejecting floorplan for outdoor location from django_loci.admin.LocationAdmin to django_loci.base.admin.AbstractLocationAdmin to ensure the extendability.

Removed code for Django 3.2
