### PR TITLE
[chores] Migrate formset function to base objectlocation mixin

### DIFF
--- a/django_loci/base/admin.py
+++ b/django_loci/base/admin.py
@@ -474,12 +474,6 @@ class ObjectLocationMixin(TimeReadonlyAdminMixin):
         ),
     )
 
-
-class AbstractObjectLocationInline(ObjectLocationMixin, GenericStackedInline):
-    """
-    Generic Inline + ObjectLocationMixin
-    """
-
     # override get_formset method to pass user to form
     def get_formset(self, request, obj=..., **kwargs):
         formset = super().get_formset(request, obj, **kwargs)
@@ -487,3 +481,9 @@ class AbstractObjectLocationInline(ObjectLocationMixin, GenericStackedInline):
             formset._construct_form, user=request.user
         )
         return formset
+
+
+class AbstractObjectLocationInline(ObjectLocationMixin, GenericStackedInline):
+    """
+    Generic Inline + ObjectLocationMixin
+    """

--- a/django_loci/tests/__init__.py
+++ b/django_loci/tests/__init__.py
@@ -96,9 +96,6 @@ class TestAdminMixin(object):
 
     def _create_readonly_admin(self, **kwargs):
         """Creates a read-only admin user with view permissions for the specified models."""
-        # during test discovery 'auth' app is not ready so import here
-        from django.contrib.auth.models import Permission
-
         models = kwargs.pop('models', [])
         user = self._create_admin(is_superuser=False, **kwargs)
         if models:
@@ -106,7 +103,7 @@ class TestAdminMixin(object):
             for model in models:
                 permission_codenames.append(f'view_{model.__name__.lower()}')
             # assign view permissions to user
-            view_permission = Permission.objects.filter(
+            view_permission = self.permission_model.objects.filter(
                 codename__in=permission_codenames
             )
             user.user_permissions.add(*view_permission)

--- a/django_loci/tests/__init__.py
+++ b/django_loci/tests/__init__.py
@@ -96,16 +96,20 @@ class TestAdminMixin(object):
 
     def _create_readonly_admin(self, **kwargs):
         """Creates a read-only admin user with view permissions for the specified models."""
-        #
+        # during test discovery 'auth' app is not ready so import here
         from django.contrib.auth.models import Permission
 
-        permission_codename = []
-        for model in kwargs.pop('models', []):
-            permission_codename.append(f'view_{model.__name__.lower()}')
-        # assign view permissions to user
-        view_permission = Permission.objects.filter(codename__in=permission_codename)
+        models = kwargs.pop('models', [])
         user = self._create_admin(is_superuser=False, **kwargs)
-        user.user_permissions.add(*view_permission)
+        if models:
+            permission_codenames = []
+            for model in models:
+                permission_codenames.append(f'view_{model.__name__.lower()}')
+            # assign view permissions to user
+            view_permission = Permission.objects.filter(
+                codename__in=permission_codenames
+            )
+            user.user_permissions.add(*view_permission)
         return user
 
     def _load_content(self, file):

--- a/django_loci/tests/__init__.py
+++ b/django_loci/tests/__init__.py
@@ -94,6 +94,20 @@ class TestAdminMixin(object):
         self.client.force_login(admin)
         return admin
 
+    def _create_readonly_admin(self, **kwargs):
+        """Creates a read-only admin user with view permissions for the specified models."""
+        #
+        from django.contrib.auth.models import Permission
+
+        permission_codename = []
+        for model in kwargs.pop('models', []):
+            permission_codename.append(f'view_{model.__name__.lower()}')
+        # assign view permissions to user
+        view_permission = Permission.objects.filter(codename__in=permission_codename)
+        user = self._create_admin(is_superuser=False, **kwargs)
+        user.user_permissions.add(*view_permission)
+        return user
+
     def _load_content(self, file):
         d = os.path.dirname(os.path.abspath(__file__))
         return open(os.path.join(d, file)).read()

--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -1,6 +1,7 @@
 import json
 
 import responses
+from django.contrib.auth.models import Permission
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.urls import reverse
 
@@ -10,6 +11,7 @@ from .. import TestAdminMixin, TestLociMixin
 class BaseTestAdmin(TestAdminMixin, TestLociMixin):
     app_label = 'django_loci'
     geocode_url = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/'
+    permission_model = Permission
 
     def test_location_list(self):
         self._login_as_admin()

--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -1,7 +1,6 @@
 import json
 
 import responses
-from django.contrib.auth.models import Permission
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.urls import reverse
 
@@ -233,12 +232,7 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
 
     # for users with view only permissions to floorplans
     def test_readonly_floorplans(self):
-        user = self.user_model.objects.create_user(
-            username='admin', password='admin', email='admin@email.org', is_staff=True
-        )
-        # add view permission to client
-        view_permission = Permission.objects.filter(codename__in=['view_floorplan'])
-        user.user_permissions.add(*view_permission)
+        user = self._create_readonly_admin(models=[self.floorplan_model])
         self.client.force_login(user)
         loc = self._create_location(name='test-admin-location-1', type='indoor')
         fl = self._create_floorplan(location=loc)

--- a/django_loci/tests/base/test_admin_inline.py
+++ b/django_loci/tests/base/test_admin_inline.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import Permission
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.db.models.fields.files import ImageFieldFile
@@ -7,6 +8,8 @@ from .. import TestAdminInlineMixin, TestLociMixin
 
 
 class BaseTestAdminInline(TestAdminInlineMixin, TestLociMixin):
+    permission_model = Permission
+
     @classmethod
     def _get_params(cls):
         _p = cls._get_prefix()

--- a/django_loci/tests/base/test_admin_inline.py
+++ b/django_loci/tests/base/test_admin_inline.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Permission
 from django.contrib.gis.geos import GEOSGeometry
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.db.models.fields.files import ImageFieldFile
@@ -866,14 +865,9 @@ class BaseTestAdminInline(TestAdminInlineMixin, TestLociMixin):
 
     # for users with view only permissions to location
     def test_readonly_indoor_location(self):
-        user = self.user_model.objects.create_user(
-            username='admin', password='admin', email='admin@email.org', is_staff=True
+        user = self._create_readonly_admin(
+            models=[self.location_model, self.floorplan_model]
         )
-        # add view permission to client
-        view_permission = Permission.objects.filter(
-            codename__in=['view_location', 'view_floorplan']
-        )
-        user.user_permissions.add(*view_permission)
         self.client.force_login(user)
         loc = self._create_location(name='test-admin-location-1', type='indoor')
         fl = self._create_floorplan(location=loc)
@@ -893,14 +887,9 @@ class BaseTestAdminInline(TestAdminInlineMixin, TestLociMixin):
 
     # for users with view only permissions to objectlocation
     def test_readonly_indoor_object_location(self):
-        user = self.user_model.objects.create_user(
-            username='admin', password='admin', email='admin@gmail.com', is_staff=True
+        user = self._create_readonly_admin(
+            models=[self.object_model, self.object_location_model]
         )
-        # add view permission to client
-        view_permission = Permission.objects.filter(
-            codename__in=['view_device', 'view_objectlocation']
-        )
-        user.user_permissions.add(*view_permission)
         self.client.force_login(user)
         obj = self._create_object(name='test-admin-object-1')
         loc = self._create_location(name='test-admin-location-1', type='indoor')
@@ -908,8 +897,7 @@ class BaseTestAdminInline(TestAdminInlineMixin, TestLociMixin):
         ol = self._create_object_location(
             content_object=obj, location=loc, floorplan=fl
         )
-        url = reverse('{0}_device_change'.format(self.object_url_prefix), args=[obj.pk])
-        r = self.client.get(url)
+        r = self.client.get(reverse(self.change_url, args=[obj.pk]))
         self.assertEqual(r.status_code, 200)
         # assert if map is being rendered or not
         self.assertContains(r, 'geometry-div-map')

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -11,13 +11,13 @@ from .. import TestAdminInlineMixin, TestLociMixin
 class BaseTestDeviceAdminSelenium(
     SeleniumTestMixin, TestAdminInlineMixin, TestLociMixin
 ):
-    def _create_device(self):
+    def _fill_device_form(self):
         self.find_element(by=By.NAME, value='name').send_keys('11:22:33:44:55:66')
 
     def test_create_new_device(self):
         self.login()
         self.open(reverse(self.add_url))
-        self._create_device()
+        self._fill_device_form()
         select = Select(
             self.find_element(
                 by=By.NAME, value=f'{self._get_prefix()}-0-location_selection'

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -11,13 +11,10 @@ from .. import TestAdminInlineMixin, TestLociMixin
 class BaseTestDeviceAdminSelenium(
     SeleniumTestMixin, TestAdminInlineMixin, TestLociMixin
 ):
-    def _fill_device_form(self):
-        self.find_element(by=By.NAME, value='name').send_keys('11:22:33:44:55:66')
-
     def test_create_new_device(self):
         self.login()
         self.open(reverse(self.add_url))
-        self._fill_device_form()
+        self.find_element(by=By.NAME, value='name').send_keys('11:22:33:44:55:66')
         select = Select(
             self.find_element(
                 by=By.NAME, value=f'{self._get_prefix()}-0-location_selection'

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -11,10 +11,13 @@ from .. import TestAdminInlineMixin, TestLociMixin
 class BaseTestDeviceAdminSelenium(
     SeleniumTestMixin, TestAdminInlineMixin, TestLociMixin
 ):
+    def _create_device(self):
+        self.find_element(by=By.NAME, value='name').send_keys('11:22:33:44:55:66')
+
     def test_create_new_device(self):
         self.login()
         self.open(reverse(self.add_url))
-        self.find_element(by=By.NAME, value='name').send_keys('11:22:33:44:55:66')
+        self._create_device()
         select = Select(
             self.find_element(
                 by=By.NAME, value=f'{self._get_prefix()}-0-location_selection'
@@ -53,7 +56,9 @@ class BaseTestDeviceAdminSelenium(
 
         self.find_element(by=By.NAME, value='_save').click()
         self.wait_for_presence(By.CSS_SELECTOR, '.messagelist .success')
+        # device model verbose name is dynamic
+        object_verbose_name = self.object_model._meta.verbose_name
         self.assertEqual(
             self.find_elements(by=By.CLASS_NAME, value='success')[0].text,
-            'The device “11:22:33:44:55:66” was added successfully.',
+            f'The {object_verbose_name} “11:22:33:44:55:66” was added successfully.',
         )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.

## Description of Changes

The get_formset_kwargs method was previously part of AbstractObjectLocationInline, which is specific to models using generic foreign keys.
Moving it to ObjectLocationMixin ensures the method is available to all models, improving reusability and consistency.
