### PR TITLE
[fix] Added address field to real-time location updates #169

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       with:
         parallel: true
         format: cobertura
-        flag-name: python-${{ matrix.env.env }}
+        flag-name: python-${{ matrix.python-version }}-${{ matrix.django-version }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
 
   coveralls:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,7 @@ jobs:
 
     - name: Tests
       if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
-      run: |
-        coverage run runtests.py --parallel --noinput --exclude-tag=selenium_tests
-        coverage run runtests.py --noinput --tag=selenium_tests
-        coverage combine
-        coverage xml
+      run: ./runtests
       env:
         SELENIUM_HEADLESS: 1
         GECKO_LOG: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,8 @@ jobs:
     - name: Tests
       if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
       run: |
-        coverage run runtests.py --parallel
+        coverage run runtests.py --parallel --exclude-tag=selenium_tests
+        coverage run runtests.py --tag=selenium_tests
         coverage combine
         coverage xml
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
     - name: Tests
       if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
       run: |
-        coverage run runtests.py --parallel --exclude-tag=selenium_tests
-        coverage run runtests.py --tag=selenium_tests
+        coverage run runtests.py --parallel --noinput --exclude-tag=selenium_tests
+        coverage run runtests.py --noinput --tag=selenium_tests
         coverage combine
         coverage xml
       env:

--- a/README.rst
+++ b/README.rst
@@ -546,8 +546,7 @@ installed locally first):
 
 .. code-block:: shell
 
-    # pytests is used to test django-channels
-    ./runtests.py && pytest
+    ./runtests
 
 Contributing
 ------------

--- a/django_loci/channels/receivers.py
+++ b/django_loci/channels/receivers.py
@@ -11,8 +11,8 @@ def update_mobile_location(sender, instance, **kwargs):
         group_name = "loci.mobile-location.{0}".format(str(instance.pk))
         channel_layer = channels.layers.get_channel_layer()
         message = {
-            'geometry': json.loads(instance.geometry.geojson),
-            'address': instance.address,
+            "geometry": json.loads(instance.geometry.geojson),
+            "address": instance.address,
         }
         async_to_sync(channel_layer.group_send)(
             group_name, {"type": "send_message", "message": message}

--- a/django_loci/channels/receivers.py
+++ b/django_loci/channels/receivers.py
@@ -11,6 +11,10 @@ def update_mobile_location(sender, instance, **kwargs):
         group_name = "loci.mobile-location.{0}".format(str(instance.pk))
         channel_layer = channels.layers.get_channel_layer()
         message = json.loads(instance.geometry.geojson)
+        message = {
+            'geometry': json.loads(instance.geometry.geojson),
+            'address': instance.address,
+        }
         async_to_sync(channel_layer.group_send)(
             group_name, {"type": "send_message", "message": message}
         )

--- a/django_loci/channels/receivers.py
+++ b/django_loci/channels/receivers.py
@@ -10,7 +10,6 @@ def update_mobile_location(sender, instance, **kwargs):
     if not kwargs.get("created") and instance.geometry:
         group_name = "loci.mobile-location.{0}".format(str(instance.pk))
         channel_layer = channels.layers.get_channel_layer()
-        message = json.loads(instance.geometry.geojson)
         message = {
             'geometry': json.loads(instance.geometry.geojson),
             'address': instance.address,

--- a/django_loci/static/django-loci/js/loci.js
+++ b/django_loci/static/django-loci/js/loci.js
@@ -448,9 +448,11 @@ django.jQuery(function ($) {
         protocol + "://" + host + "/ws/loci/location/" + pk + "/",
       );
     ws.onmessage = function (e) {
+      const data = JSON.parse(e.data);
       $geometryRow.show();
       $noLocationDiv.hide();
-      $geometryTextarea.val(e.data);
+      $geometryTextarea.val(JSON.stringify(data.geometry));
+      $address.val(data.address);
       getMap().remove();
       window[loadMapName]();
     };

--- a/django_loci/tests/base/test_channels.py
+++ b/django_loci/tests/base/test_channels.py
@@ -143,7 +143,11 @@ class BaseTestChannels(TestAdminMixin, TestLociMixin):
         assert connected
         await self._save_location(request_vars["pk"])
         response = await communicator.receive_json_from()
-        assert response == {"type": "Point", "coordinates": [12.513124, 41.897903]}
+        print(response)
+        assert response == {
+            "geometry": {"type": "Point", "coordinates": [12.513124, 41.897903]},
+            "address": "Via del Corso, Roma, Italia",
+        }
         await communicator.disconnect()
 
     async def _save_location(self, pk):

--- a/django_loci/tests/base/test_channels.py
+++ b/django_loci/tests/base/test_channels.py
@@ -143,7 +143,6 @@ class BaseTestChannels(TestAdminMixin, TestLociMixin):
         assert connected
         await self._save_location(request_vars["pk"])
         response = await communicator.receive_json_from()
-        print(response)
         assert response == {
             "geometry": {"type": "Point", "coordinates": [12.513124, 41.897903]},
             "address": "Via del Corso, Roma, Italia",

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -1,9 +1,10 @@
+from time import sleep
+
 from django.urls.base import reverse
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
-from time import sleep
 
 from openwisp_utils.tests import SeleniumTestMixin
 
@@ -13,6 +14,7 @@ from .. import TestAdminInlineMixin, TestLociMixin
 class BaseTestDeviceAdminSelenium(
     SeleniumTestMixin, TestAdminInlineMixin, TestLociMixin
 ):
+
     def _fill_device_form(self):
         """
         This method can be extended by downstram implementations
@@ -92,12 +94,12 @@ class BaseTestDeviceAdminSelenium(
         alert = WebDriverWait(self.web_driver, 2).until(EC.alert_is_present())
         alert.accept()
         sleep(0.5)
-        new_address = "Via dei Ramni, Roma, Lazio 00185, ITA"
+        new_address = "Lazio 00185, ITA"
         address_input = self.find_element(by=By.ID, value="id_address")
-        self.assertEqual(address_input.get_attribute("value"), new_address)
-        self.find_element(by=By.NAME, value="_save").click()
+        self.assertIn(new_address, address_input.get_attribute("value"))
+        self.wait_for("element_to_be_clickable", by=By.NAME, value="_continue").click()
         # Close tab[1] so other tests are not affected
         self.web_driver.close()
         self.web_driver.switch_to.window(tabs[0])
         address_input = self.find_element(by=By.ID, value="id_address")
-        self.assertEqual(address_input.get_attribute("value"), new_address)
+        self.assertIn(new_address, address_input.get_attribute("value"))

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -71,7 +71,7 @@ class BaseTestDeviceAdminSelenium(
             f"The {object_verbose_name} “11:22:33:44:55:66” was added successfully.",
         )
 
-    def test_address_field_real_time_update(self):
+    def test_real_time_update_address_field(self):
         location = self._create_location()
         self.login()
         url = reverse("admin:django_loci_location_change", args=[location.id])

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -3,6 +3,7 @@ from selenium.webdriver import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
+from time import sleep
 
 from openwisp_utils.tests import SeleniumTestMixin
 
@@ -90,6 +91,7 @@ class BaseTestDeviceAdminSelenium(
         ).click().perform()
         alert = WebDriverWait(self.web_driver, 2).until(EC.alert_is_present())
         alert.accept()
+        sleep(0.5)
         new_address = "Via dei Ramni, Roma, Lazio 00185, ITA"
         address_input = self.find_element(by=By.ID, value="id_address")
         self.assertEqual(address_input.get_attribute("value"), new_address)

--- a/django_loci/tests/base/test_selenium.py
+++ b/django_loci/tests/base/test_selenium.py
@@ -79,7 +79,8 @@ class BaseTestDeviceAdminSelenium(
         # Changing the address in tab 1 should update it in tab 0 in real time without a page reload
         self.web_driver.switch_to.new_window("tab")
         tabs = self.web_driver.window_handles
-        self.web_driver.switch_to.window(tabs[1])
+        # Swtich to last tab
+        self.web_driver.switch_to.window(tabs[-1])
         self.open(url)
         address_input = self.find_element(by=By.ID, value="id_address")
         self.assertEqual(address_input.get_attribute("value"), location.address)
@@ -93,13 +94,16 @@ class BaseTestDeviceAdminSelenium(
         ).click().perform()
         alert = WebDriverWait(self.web_driver, 2).until(EC.alert_is_present())
         alert.accept()
-        sleep(0.5)
+        sleep(0.05)
         new_address = "Lazio 00185, ITA"
         address_input = self.find_element(by=By.ID, value="id_address")
         self.assertIn(new_address, address_input.get_attribute("value"))
         self.wait_for("element_to_be_clickable", by=By.NAME, value="_continue").click()
         # Close tab[1] so other tests are not affected
         self.web_driver.close()
-        self.web_driver.switch_to.window(tabs[0])
+        # on some systems the zero tab may be an empty tab
+        # hence we open the tab before the last one
+        initial_tab = tabs.index(tabs[-1]) - 1
+        self.web_driver.switch_to.window(tabs[initial_tab])
         address_input = self.find_element(by=By.ID, value="id_address")
         self.assertIn(new_address, address_input.get_attribute("value"))

--- a/django_loci/tests/test_selenium.py
+++ b/django_loci/tests/test_selenium.py
@@ -1,12 +1,14 @@
+from channels.testing import ChannelsLiveServerTestCase
 from django.contrib.auth import get_user_model
-from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import tag
 
 from ..models import Location, ObjectLocation
 from .base.test_selenium import BaseTestDeviceAdminSelenium
 from .testdeviceapp.models import Device
 
 
-class TestDeviceAdminSelenium(BaseTestDeviceAdminSelenium, StaticLiveServerTestCase):
+@tag("selenium_tests")
+class TestDeviceAdminSelenium(BaseTestDeviceAdminSelenium, ChannelsLiveServerTestCase):
     user_model = get_user_model()
     object_model = Device
     location_model = Location

--- a/runtests
+++ b/runtests
@@ -2,6 +2,6 @@
 set -e
 
 coverage run runtests.py --parallel --exclude-tag=selenium_tests
-coverage run runtests.py --tag=selenium_tests
+coverage run runtests.py --tag=selenium_tests --exclude-pytest
 coverage combine
 coverage xml

--- a/runtests
+++ b/runtests
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+coverage run runtests.py --parallel --exclude-tag=selenium_tests
+coverage run runtests.py --tag=selenium_tests
+coverage combine
+coverage xml

--- a/runtests.py
+++ b/runtests.py
@@ -12,7 +12,16 @@ if __name__ == "__main__":
     from django.core.management import execute_from_command_line
 
     args = sys.argv
+    exclude_pytest = "--exclude-pytest" in args
+    if exclude_pytest:
+        args.pop(args.index("--exclude-pytest"))
+
     args.insert(1, "test")
     args.insert(2, "django_loci")
-    execute_from_command_line(args)
-    sys.exit(pytest.main([os.path.join("django_loci", "tests")]))
+    django_tests = execute_from_command_line(args)
+
+    if not exclude_pytest:
+        # pytests is used to test django-channels
+        sys.exit(pytest.main([os.path.join("django_loci", "tests")]))
+    else:
+        sys.exit(django_tests)

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -12,6 +12,9 @@ DATABASES = {
     "default": {
         "ENGINE": "openwisp_utils.db.backends.spatialite",
         "NAME": "django-loci.db",
+        "TEST": {
+            "NAME": "openwisp_utils_test.db",
+        },
     }
 }
 

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -16,7 +16,7 @@ DATABASES = {
 }
 if TESTING and "--exclude-tag=selenium_tests" not in sys.argv:
     DATABASES["default"]["TEST"] = {
-        "NAME": os.path.join(BASE_DIR, "django-loci.db.db"),
+        "NAME": os.path.join(BASE_DIR, "django-loci-test.db"),
     }
 
 SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -12,11 +12,12 @@ DATABASES = {
     "default": {
         "ENGINE": "openwisp_utils.db.backends.spatialite",
         "NAME": "django-loci.db",
-        "TEST": {
-            "NAME": "openwisp_utils_test.db",
-        },
     }
 }
+if TESTING and "--exclude-tag=selenium_tests" not in sys.argv:
+    DATABASES["default"]["TEST"] = {
+        "NAME": os.path.join(BASE_DIR, "django-loci.db.db"),
+    }
 
 SPATIALITE_LIBRARY_PATH = "mod_spatialite.so"
 


### PR DESCRIPTION
Added address update handling in the websocket message and updated listenForLocationUpdates logic accordingly.

Fixes #169

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Reference to Existing Issue

Closes #169.

## Description of Changes

- Updated the real-time update logic to include address field updates via WebSocket.
- Modified the `listenForLocationUpdates` function to handle and broadcast address changes.

## Issues

- Inheriting from `ChannelLiveServerTestCase` is causing test failures in Django 5.2, which is a new release, and a fix has yet to be released for it.

- Adding `ChannelLiveServerTestCase` prevents running tests in parallel with the --parallel flag, as it relies on live WebSocket connections that cannot run concurrently.

## Demo

[real-time-address.webm](https://github.com/user-attachments/assets/9cec1fda-b51e-4db9-8e32-cc02050fee20)
