### PR TITLE
[css:django 5] Hide redundant heading in ObjectLocationInline

### DIFF
--- a/django_loci/static/django-loci/css/loci.css
+++ b/django_loci/static/django-loci/css/loci.css
@@ -7,7 +7,8 @@
   display: block;
 }
 /* hide redundant heading in objectlocationinline */
-.loci.coords > h2 {
+.loci.coords > h2,
+.loci.coords > h4 {
   display: none;
 }
 /* improve raw_id_field look */


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
