### PR TITLE
[backport][fix] Updated higher bound of pillow range due to CVE #215

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
                gdal-bin
           pip install -U -r requirements-test.txt
           sudo npm install -g prettier
+          pip install -U "setuptools<82"  # for Python 3.9
           pip install -U -e .
           pip install -U ${{ matrix.django-version }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django>=4.2.0,<5.3.0
 django-leaflet~=0.32.0
-Pillow~=11.3.0
+Pillow>=11.3.0,<12.3.0
 geopy~=2.4.1
 openwisp-utils[channels]~=1.2.0


### PR DESCRIPTION
Required pillow>=12.1.1 due to CVE.

Backward compatibility with Python 3.9 is maintained
but insecure and not recommended, it's already removed
in master and it's highly recommended to upgrade to
Python 3.10 or newer.

Backport of #213.
Related to #215.