### PR TITLE
[fix] Fixed ObjectLocation admin read-only mode on Django >= 6

### DIFF
--- a/django_loci/apps.py
+++ b/django_loci/apps.py
@@ -42,7 +42,10 @@ class LociConfig(AppConfig):
     def ready(self):
         import leaflet
 
+        from .base.admin import restore_readonly_widget_rendering
+
         leaflet.app_settings["NO_GLOBALS"] = False
+        restore_readonly_widget_rendering()
         self.__setmodels__()
         self._load_receivers()
 

--- a/django_loci/base/admin.py
+++ b/django_loci/base/admin.py
@@ -4,9 +4,11 @@ from functools import partialmethod
 from django import forms
 from django.contrib import admin
 from django.contrib.admin import widgets
+from django.contrib.admin.helpers import AdminReadonlyField
 from django.contrib.admin.sites import site
+from django.contrib.admin.utils import lookup_field
 from django.contrib.contenttypes.admin import GenericStackedInline
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import path
@@ -20,6 +22,38 @@ from ..base.geocoding_views import geocode_view, reverse_geocode_view
 from ..fields import GeometryField
 from ..widgets import FloorPlanWidget, ImageWidget
 from .models import AbstractFloorPlan, AbstractLocation
+
+
+def restore_readonly_widget_rendering():
+    """
+    Renders read-only widgets (map, floorplan, image) for view-only users.
+
+    Django 6.0 dropped the ``AdminReadonlyField.contents()`` code path that
+    rendered a widget when its ``read_only`` attribute was set, breaking the
+    read-only admin (see issue #95). This restores it only for widgets that
+    opt-in via ``read_only = True``, so other admins are unaffected.
+    """
+    if getattr(AdminReadonlyField, "_loci_readonly_patched", False):
+        return
+    original_contents = AdminReadonlyField.contents
+
+    def contents(self):
+        field = self.field["field"]
+        if field in self.form.fields:
+            widget = self.form[field].field.widget
+            if getattr(widget, "read_only", False):
+                try:
+                    _, _, value = lookup_field(
+                        field, self.form.instance, self.model_admin
+                    )
+                except (AttributeError, ValueError, ObjectDoesNotExist):
+                    pass
+                else:
+                    return widget.render(field, value)
+        return original_contents(self)
+
+    AdminReadonlyField.contents = contents
+    AdminReadonlyField._loci_readonly_patched = True
 
 
 class ReadOnlyMixin:

--- a/django_loci/tests/base/test_admin.py
+++ b/django_loci/tests/base/test_admin.py
@@ -1,6 +1,10 @@
 import json
 
 import responses
+from django import forms
+from django.contrib.admin import ModelAdmin
+from django.contrib.admin.helpers import AdminReadonlyField
+from django.contrib.admin.sites import site
 from django.contrib.auth.models import Permission
 from django.contrib.humanize.templatetags.humanize import ordinal
 from django.urls import reverse
@@ -279,3 +283,23 @@ class BaseTestAdmin(TestAdminMixin, TestLociMixin):
         self.assertContains(r, f"{loc.name} {ordinal(fl.floor)}")
         self.assertContains(r, fl.floor)
         self.assertContains(r, loc.name)
+
+    def test_restore_readonly_widget_rendering(self):
+        class ReadOnlyWidget(forms.TextInput):
+            read_only = True
+
+            def render(self, name, value, attrs=None, renderer=None):
+                return f"read-only {value}"
+
+        def contents(name, form, model_admin):
+            field = AdminReadonlyField(
+                form, name, is_first=True, model_admin=model_admin
+            )
+            return field.contents()
+
+        loc = self._create_location(name="test-admin-location-1")
+        admin = ModelAdmin(self.location_model, site)
+        form = forms.modelform_factory(
+            self.location_model, fields=["name"], widgets={"name": ReadOnlyWidget}
+        )(instance=loc)
+        self.assertEqual(contents("name", form, admin), f"read-only {loc.name}")


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #95

## Description of Changes

Django 6.0 removed the AdminReadonlyField.contents() path the previous #158 fix relied on, so the map/image widgets stopped rendering for view-only users. The fix re-adds it in AppConfig.ready(), only for widgets that set read_only=True.

Before:
<img width="3122" height="2381" alt="image" src="https://github.com/user-attachments/assets/2100eb2f-6d74-44ef-8915-aca81bec258e" />

After:
<img width="3122" height="3076" alt="image" src="https://github.com/user-attachments/assets/d319bfed-c456-48c9-979c-0caa093879c9" />
